### PR TITLE
Try to fix weeks gaps

### DIFF
--- a/ooui/graph/timerange.py
+++ b/ooui/graph/timerange.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
+from ooui.helpers.dates import datetime_from_string
 from ooui.graph.fields import get_value_for_operator
 
 
@@ -101,8 +102,8 @@ def get_missing_consecutive_dates(dates, timerange, interval=1):
     sorted_dates = sorted(dates)
 
     for i in range(len(sorted_dates) - 1):
-        date1 = datetime.strptime(sorted_dates[i], format_str)
-        date2 = datetime.strptime(sorted_dates[i + 1], format_str)
+        date1 = datetime_from_string(sorted_dates[i], format_str)
+        date2 = datetime_from_string(sorted_dates[i + 1], format_str)
 
         next_date = add_time_unit(date1, interval, units)
 

--- a/ooui/graph/timerange.py
+++ b/ooui/graph/timerange.py
@@ -172,8 +172,8 @@ def convert_date_to_time_range_adjusted(date, timerange):
     :rtype: str
     :returns: The adjusted date in the specified time range format.
     """
-    format_str = get_date_format(date)
-    moment_date = datetime.strptime(date, format_str)
+    format_str = get_date_format(date, timerange)
+    moment_date = datetime_from_string(date, format_str)
 
     if timerange == 'hour':
         return moment_date.strftime('%Y-%m-%d %H:00')
@@ -189,7 +189,7 @@ def convert_date_to_time_range_adjusted(date, timerange):
         raise ValueError("Unsupported timerange: {}".format(timerange))
 
 
-def get_date_format(date_str):
+def get_date_format(date_str, timerange=None):
     """
     Determine the appropriate date format string based on whether the input
     string contains a colon.
@@ -203,7 +203,10 @@ def get_date_format(date_str):
     if ':' in date_str:
         return '%Y-%m-%d %H:%M:%S'
     elif date_str.count('-') == 1:
-        return '%Y-%m'
+        if timerange == 'month':
+            return '%Y-%m'
+        else:
+            return '%Y-%W'
     else:
         return '%Y-%m-%d'
 
@@ -281,8 +284,8 @@ def check_dates_consecutive(dates, unit):
     format_str = get_format_for_units(unit)
 
     for i in range(len(dates) - 1):
-        date1 = datetime.strptime(dates[i], format_str)
-        date2 = datetime.strptime(dates[i + 1], format_str)
+        date1 = datetime_from_string(dates[i], format_str)
+        date2 = datetime_from_string(dates[i + 1], format_str)
 
         if unit == 'hours':
             diff = (date2 - date1).total_seconds() / 3600

--- a/ooui/helpers/dates.py
+++ b/ooui/helpers/dates.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+def datetime_from_string(string, format_str):
+    if format_str == '%Y-%W':
+        # The "%W" format string doesn't work with strptime, so we need to
+        # manually parse the week number and year.
+        return datetime.strptime(string + '-0', '%Y-%W-%w')
+    return datetime.strptime(string, format_str)

--- a/ooui/helpers/dates.py
+++ b/ooui/helpers/dates.py
@@ -5,4 +5,8 @@ def datetime_from_string(string, format_str):
         # The "%W" format string doesn't work with strptime, so we need to
         # manually parse the week number and year.
         return datetime.strptime(string + '-0', '%Y-%W-%w')
+    elif format_str == "%Y-%m-%d":
+        return datetime.strptime(string[:10], format_str)
+    elif format_str == "%Y-%m-%d %H:%M":
+        return datetime.strptime(string[:16], format_str)
     return datetime.strptime(string, format_str)

--- a/spec/graph/timerange_spec.py
+++ b/spec/graph/timerange_spec.py
@@ -364,6 +364,36 @@ with description('Testing process_timerange_data') as self:
              'type': 'Revenue', 'value': 300.0},
             ))
 
+        with it('should return the final combined and filled values by week'):
+            values_data = [
+                {'x': '2024-01', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 100, 'operator': '+'},
+                {'x': '2024-02', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 200, 'operator': '+'},
+                {'x': '2024-03', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 300, 'operator': '+'},
+                {'x': '2024-05', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 500, 'operator': '+'}
+            ]
+
+            result = process_timerange_data(
+                values_data, 'week', 1,
+            )
+
+            expect(result).to(contain_only(
+                {'x': '2024-01', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 100, 'operator': '+'},
+                {'x': '2024-02', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 200, 'operator': '+'},
+                {'x': '2024-03', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 300, 'operator': '+'},
+                {'x': '2024-04', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 0},
+                {'x': '2024-05', 'type': 'Revenue', 'stacked': 'A',
+                 'value': 500, 'operator': '+'}
+            ))
+
+
     with description('add_time_unit function'):
         with context('when adding different time units'):
             with it('adds days correctly'):

--- a/spec/graph/timerange_spec.py
+++ b/spec/graph/timerange_spec.py
@@ -240,11 +240,17 @@ with description('Testing get_missing_consecutive_dates') as self:
             result = get_missing_consecutive_dates(dates_data, 'month')
             expect(result).to(equal(['2024-02', '2024-04']))
 
+    with context('when checking for missing weeks'):
+        with it('should return a list of missing weeks'):
+            dates_data = ['2024-01', '2024-03', '2024-05']
+            result = get_missing_consecutive_dates(dates_data, 'week')
+            expect(result).to(equal(['2024-02', '2024-04']))
+
 
 with description('Testing fill_gaps_in_timerange_data') as self:
 
     with context('when filling gaps in time range data'):
-        with it('should return the final values with gaps filled'):
+        with it('should return the final values with gaps filled by day'):
             values_data = [
                 {'x': '2024-05-01', 'type': 'Revenue', 'stacked': 'A', 'value': 100},
                 {'x': '2024-05-05', 'type': 'Revenue', 'stacked': 'A', 'value': 200},
@@ -260,6 +266,22 @@ with description('Testing fill_gaps_in_timerange_data') as self:
                 {'x': '2024-05-04', 'type': 'Revenue', 'stacked': 'A', 'value': 0},
                 {'x': '2024-05-05', 'type': 'Revenue', 'stacked': 'A', 'value': 200},
                 {'x': '2024-06-01', 'type': 'Profit', 'stacked': 'B', 'value': 300}
+            ))
+
+        with it('should return the final values with gaps filled by week'):
+            values_data = [
+                {'x': '2024-01', 'type': 'Revenue', 'stacked': 'A', 'value': 100},
+                {'x': '2024-02', 'type': 'Revenue', 'stacked': 'A', 'value': 200},
+                {'x': '2024-04', 'type': 'Revenue', 'stacked': 'A', 'value': 300}
+            ]
+
+            result = fill_gaps_in_timerange_data(values_data, 'week', 1)
+
+            expect(result).to(contain_only(
+                {'x': '2024-01', 'type': 'Revenue', 'stacked': 'A', 'value': 100},
+                {'x': '2024-02', 'type': 'Revenue', 'stacked': 'A', 'value': 200},
+                {'x': '2024-03', 'type': 'Revenue', 'stacked': 'A', 'value': 0},
+                {'x': '2024-04', 'type': 'Revenue', 'stacked': 'A', 'value': 300},
             ))
 
 


### PR DESCRIPTION
This pull request introduces several changes to the `ooui/graph/timerange.py` file and its associated test suite to enhance date handling and add support for weekly time ranges. The most important changes include the addition of a new helper function for date parsing, modifications to existing functions to utilize this helper, and updates to the test suite to cover the new functionality.

Improvements to date handling:

* [`ooui/helpers/dates.py`](diffhunk://#diff-4902d86fa0de41c8f8594420fbd6b0b0b95d15b26c4995a7c7117d3e1c16a2e3R1-R12): Added a new helper function `datetime_from_string` to handle various date formats, including weekly dates.
* [`ooui/graph/timerange.py`](diffhunk://#diff-4cb473d417862e7ac337a192d6f94c06b26cad5a69d50a617800d09e975b7623L104-R106): Updated functions `get_missing_consecutive_dates`, `convert_date_to_time_range_adjusted`, and `check_dates_consecutive` to use the new `datetime_from_string` helper function for parsing dates. [[1]](diffhunk://#diff-4cb473d417862e7ac337a192d6f94c06b26cad5a69d50a617800d09e975b7623L104-R106) [[2]](diffhunk://#diff-4cb473d417862e7ac337a192d6f94c06b26cad5a69d50a617800d09e975b7623L174-R176) [[3]](diffhunk://#diff-4cb473d417862e7ac337a192d6f94c06b26cad5a69d50a617800d09e975b7623L283-R288)

Support for weekly time ranges:

* [`ooui/graph/timerange.py`](diffhunk://#diff-4cb473d417862e7ac337a192d6f94c06b26cad5a69d50a617800d09e975b7623R206-R209): Modified the `get_date_format` function to return the correct format string for weekly dates.
* [`spec/graph/timerange_spec.py`](diffhunk://#diff-a9e28da0906c2f7326ea778964601c16f8893c540ea8906e6642ecea4aff8f7bR243-R253): Added new test cases to verify the handling of weekly time ranges in `get_missing_consecutive_dates`, `fill_gaps_in_timerange_data`, and `process_timerange_data`. [[1]](diffhunk://#diff-a9e28da0906c2f7326ea778964601c16f8893c540ea8906e6642ecea4aff8f7bR243-R253) [[2]](diffhunk://#diff-a9e28da0906c2f7326ea778964601c16f8893c540ea8906e6642ecea4aff8f7bR271-R286) [[3]](diffhunk://#diff-a9e28da0906c2f7326ea778964601c16f8893c540ea8906e6642ecea4aff8f7bR367-R396)

## Related

- Closes https://github.com/gisce/webclient/issues/1586