### PR TITLE
Allow to pass precission for every field in Aggregator

### DIFF
--- a/ooui/helpers/aggregated.py
+++ b/ooui/helpers/aggregated.py
@@ -2,23 +2,29 @@ from __future__ import absolute_import, unicode_literals
 
 
 class Aggregator:
-    def __init__(self, data, field_definitions):
+    def __init__(self, data, field_definitions, precisions=None):
         self.data = data
         self.field_definitions = field_definitions
+        self.precisions = precisions or {}
 
     def process(self):
         results = {}
         for field, functions in self.field_definitions.items():
+            precision = self.precisions.get(field)
             values = [item[field] for item in self.data if field in item]
             results[field] = {}
             if 'sum' in functions:
-                results[field]['sum'] = sum(values)
+                result = sum(values)
+                results[field]['sum'] = precision and round(result, precision) or result
             if 'count' in functions:
-                results[field]['count'] = len(values)
+                results[field]['count'] = round(len(values), precision)
             if 'avg' in functions:
-                results[field]['avg'] = sum(values) / float(len(values)) if values else 0
+                result = sum(values) / float(len(values)) if values else 0
+                results[field]['avg'] = precision and round(result, precision) or result
             if 'max' in functions:
-                results[field]['max'] = max(values)
+                result = max(values) if values else 0
+                results[field]['max'] = precision and round(result, precision) or result
             if 'min' in functions:
-                results[field]['min'] = min(values)
+                result = min(values) if values else 0
+                results[field]['min'] = precision and round(result, precision) or result
         return results

--- a/spec/aggregated_spec.py
+++ b/spec/aggregated_spec.py
@@ -26,3 +26,23 @@ with description('Aggregator class'):
             expect(results['value']['avg']).to(equal(15))
             expect(results['value']['max']).to(equal(20))
             expect(results['value']['min']).to(equal(10))
+
+    with context('Using precision in aggregation'):
+
+        with it('should use the precision for the field'):
+            data = [{'value': 10.1235}, {'value': 20.1233}, {'value': 30.1238}]
+            field_definitions = {'value': ['sum']}
+            precisions = {'value': 3}
+            aggregator = Aggregator(data, field_definitions, precisions)
+            results = aggregator.process()
+
+            expect(results['value']['sum']).to(equal(60.371))
+
+
+        with it('not should round if is an integer'):
+            data = [{'value': 10}, {'value': 20}, {'value': 30}]
+            field_definitions = {'value': ['sum']}
+            aggregator = Aggregator(data, field_definitions)
+            results = aggregator.process()
+
+            expect(str(results['value']['sum'])).to(equal(str(60)))


### PR DESCRIPTION
This pull request introduces enhancements to the `Aggregator` class to support precision handling for aggregated fields and updates the corresponding tests to verify this new functionality.

### Enhancements to Aggregator class:

* [`ooui/helpers/aggregated.py`](diffhunk://#diff-24fe79b8d5848aee188d7dbe4e571d534d3f163b9af8f43e64174fb95dfa59e5L5-R29): Added an optional `precisions` parameter to the `Aggregator` class to allow specifying the precision for each field. Updated the `process` method to use this precision when performing aggregation functions like `sum`, `count`, `avg`, `max`, and `min`.

### Updates to tests:

* [`spec/aggregated_spec.py`](diffhunk://#diff-3158122c44d9644f1915eddaf643d86a6b282406cba847881b150abb2c035933R29-R48): Added new tests to verify that the `Aggregator` class correctly handles precision for fields during aggregation. These tests ensure that the precision is applied correctly for floating-point numbers and that integers are not rounded.