### PR TITLE
Conditions: get involved fields of a condition

### DIFF
--- a/ooui/helpers/conditions.py
+++ b/ooui/helpers/conditions.py
@@ -5,6 +5,23 @@ from datetime import datetime
 from simpleeval import EvalWithCompoundTypes, DEFAULT_OPERATORS, DEFAULT_NAMES
 
 
+class DummyObject:
+    def __eq__(self, other): return True
+    def __ne__(self, other): return True
+    def __lt__(self, other): return True
+    def __le__(self, other): return True
+    def __gt__(self, other): return True
+    def __ge__(self, other): return True
+    def __add__(self, other): return self
+    def __sub__(self, other): return self
+    def __mul__(self, other): return self
+    def __truediv__(self, other): return self
+    def __floordiv__(self, other): return self
+    def __mod__(self, other): return self
+    def __pow__(self, other): return self
+    def __repr__(self): return "DummyObject"
+
+
 class GetFieldsDict(dict):
 
     def __init__(self, *args, **kwargs):
@@ -14,7 +31,7 @@ class GetFieldsDict(dict):
     def __getitem__(self, key):
         if key not in self:
             self.fields.add(key)
-        return dict.get(self, key, key)
+        return dict.get(self, key, DummyObject())
 
 
 class ConditionParser(object):

--- a/ooui/helpers/conditions.py
+++ b/ooui/helpers/conditions.py
@@ -28,15 +28,15 @@ class ConditionParser(object):
 
     @property
     def involved_fields(self):
-        magic_dict = GetFieldsDict()
-        magic_dict.update(self.values)
-        magic_dict.update(DEFAULT_NAMES)
+        fields_tracker = GetFieldsDict()
+        fields_tracker.update(self.values)
+        fields_tracker.update(DEFAULT_NAMES)
         for key, condition in self.conditions:
             s = EvalWithCompoundTypes(
-                names=magic_dict, functions=self.functions, operators=self.operators
+                names=fields_tracker, functions=self.functions, operators=self.operators
             )
             s.eval(condition)
-        return magic_dict.fields
+        return fields_tracker.fields
 
     def eval(self, values):
         if not self.conditions:

--- a/ooui/helpers/conditions.py
+++ b/ooui/helpers/conditions.py
@@ -5,6 +5,18 @@ from datetime import datetime
 from simpleeval import EvalWithCompoundTypes, DEFAULT_OPERATORS, DEFAULT_NAMES
 
 
+class GetFieldsDict(dict):
+
+    def __init__(self, *args, **kwargs):
+        super(GetFieldsDict, self).__init__(*args, **kwargs)
+        self.fields = set()
+
+    def __getitem__(self, key):
+        if key not in self:
+            self.fields.add(key)
+        return dict.get(self, key, key)
+
+
 class ConditionParser(object):
     def __init__(self, condition):
         self.raw_condition = condition
@@ -13,6 +25,18 @@ class ConditionParser(object):
         self.operators = DEFAULT_OPERATORS.copy()
         self.operators[ast.BitAnd] = operator.and_
         self.values = {'current_date': datetime.now().strftime('%Y-%m-%d')}
+
+    @property
+    def involved_fields(self):
+        magic_dict = GetFieldsDict()
+        magic_dict.update(self.values)
+        magic_dict.update(DEFAULT_NAMES)
+        for key, condition in self.conditions:
+            s = EvalWithCompoundTypes(
+                names=magic_dict, functions=self.functions, operators=self.operators
+            )
+            s.eval(condition)
+        return magic_dict.fields
 
     def eval(self, values):
         if not self.conditions:

--- a/ooui/tree/__init__.py
+++ b/ooui/tree/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import, unicode_literals
+from .base import Tree
+
+
+def parse_tree(xml):
+    """
+    Parse a tree from an XML string.
+    :param xml:
+    :return:
+    :rtype ooui.tree.Tree
+    """
+    from lxml import etree
+
+    tree = etree.fromstring(xml)
+    tree = tree.xpath('//tree')[0]
+    return Tree(tree)

--- a/ooui/tree/base.py
+++ b/ooui/tree/base.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, unicode_literals
+from ooui.helpers.conditions import ConditionParser
+
+
+class Tree(object):
+    def __init__(self, element):
+        """
+        :param element: lxml.etree._Element
+        """
+        self._string = element.get('string')
+        self._infinite = element.get('infinite', None)
+        self._colors = element.get('colors', None)
+        self._status = element.get('status', None)
+        self._editable = element.get('editable', None)
+        self._element = element
+
+
+    @property
+    def string(self):
+        return self._string
+
+    @property
+    def infinite(self):
+        return self._infinite
+
+    @property
+    def fields(self):
+        res = []
+        for field in self._element.xpath('field'):
+            res.append(field)
+        return res
+
+    @property
+    def fields_in_conditions(self):
+        res = {}
+        if self._colors:
+            parser = ConditionParser(self._colors)
+            res['colors'] = parser.involved_fields
+        if self._status:
+            parser = ConditionParser(self._status)
+            res['status'] = parser.involved_fields
+        return res

--- a/ooui/tree/base.py
+++ b/ooui/tree/base.py
@@ -35,8 +35,8 @@ class Tree(object):
         res = {}
         if self._colors:
             parser = ConditionParser(self._colors)
-            res['colors'] = parser.involved_fields
+            res['colors'] = list(parser.involved_fields)
         if self._status:
             parser = ConditionParser(self._status)
-            res['status'] = parser.involved_fields
+            res['status'] = list(parser.involved_fields)
         return res

--- a/spec/graph/helpers_spec.py
+++ b/spec/graph/helpers_spec.py
@@ -44,7 +44,7 @@ with description('Helpers module'):
                 result = self.cond.eval({'active': True, 'meter_type': 'X'})
                 expect(result).to(be_none)
 
-            with it('should use time builin'):
+            with it('should use time builtin'):
                 c = ConditionParser("grey:reconcile_id!=0;blue:amount_to_pay==0;red:date_maturity<time.strftime('%Y-%m-%d')")
                 from datetime import datetime, timedelta
                 dm = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
@@ -73,6 +73,13 @@ with description('Helpers module'):
             with it('should eval without conditions'):
                 c = ConditionParser("slack")
                 expect(c.eval({'patata': 1})).to(equal('slack'))
+
+            with description('When analyzing for involved fields'):
+                with it('should return involved fields'):
+                    c = ConditionParser(
+                        "grey:state in ('cancel','done');blue:remaining_hours<0;red:bool(date_deadline) & (date_deadline<current_date) & (state in ('draft','open'))")
+                    expect(c.involved_fields).to(
+                        equal({'state', 'remaining_hours', 'date_deadline'}))
 
     with description('when evaluating a domain'):
         with description("an empty domain"):

--- a/spec/tree/tree_spec.py
+++ b/spec/tree/tree_spec.py
@@ -42,5 +42,5 @@ with description('Tree') as self:
                             status="green:active==True"/>'''
             tree = parse_tree(xml)
             fields = tree.fields_in_conditions
-            expect(fields['colors']).to(equal({'state'}))
-            expect(fields['status']).to(equal({'active'}))
+            expect(fields['colors']).to(equal(['state']))
+            expect(fields['status']).to(equal(['active']))

--- a/spec/tree/tree_spec.py
+++ b/spec/tree/tree_spec.py
@@ -1,0 +1,46 @@
+from mamba import description, context, it
+from expects import expect, equal
+from ooui.tree import parse_tree
+
+with description('Tree') as self:
+    with context('when initialized with an element'):
+        with it('should set the string attribute'):
+            xml = '<tree string="Test String"/>'
+            tree = parse_tree(xml)
+            expect(tree.string).to(equal('Test String'))
+
+        with it('should set the infinite attribute'):
+            xml = '<tree infinite="True"/>'
+            tree = parse_tree(xml)
+            expect(tree.infinite).to(equal('True'))
+
+        with it('should set the colors attribute'):
+            xml = '''<tree colors="red:state=='error'"/>'''
+            tree = parse_tree(xml)
+            expect(tree._colors).to(equal("red:state=='error'"))
+
+        with it('should set the status attribute'):
+            xml = '<tree status="active"/>'
+            tree = parse_tree(xml)
+            expect(tree._status).to(equal('active'))
+
+        with it('should set the editable attribute'):
+            xml = '<tree editable="yes"/>'
+            tree = parse_tree(xml)
+            expect(tree._editable).to(equal('yes'))
+
+        with it('should return the fields'):
+            xml = '<tree><field name="field1"/><field name="field2"/></tree>'
+            tree = parse_tree(xml)
+            fields = tree.fields
+            expect(len(fields)).to(equal(2))
+            expect(fields[0].get('name')).to(equal('field1'))
+            expect(fields[1].get('name')).to(equal('field2'))
+
+        with it('should return fields in conditions'):
+            xml = '''<tree colors="red:state=='error';blue:state=='done';green:state=='draft';"
+                            status="green:active==True"/>'''
+            tree = parse_tree(xml)
+            fields = tree.fields_in_conditions
+            expect(fields['colors']).to(equal({'state'}))
+            expect(fields['status']).to(equal({'active'}))


### PR DESCRIPTION
This pull request includes several changes to the `ooui` package, focusing on adding new functionality for parsing and handling conditions and trees. The most important changes include the introduction of the `GetFieldsDict` class, enhancements to the `ConditionParser` class, the addition of a `Tree` class, and new test cases for these components.

### Enhancements to condition handling:

* Added `GetFieldsDict` class to track accessed fields in the `ConditionParser` class (`ooui/helpers/conditions.py`).
* Introduced `involved_fields` property in `ConditionParser` to identify fields involved in conditions (`ooui/helpers/conditions.py`).

### Tree parsing and handling:

* Added `parse_tree` function to parse XML strings into `Tree` objects (`ooui/tree/__init__.py`).
* Introduced `Tree` class with properties and methods to handle XML tree elements (`ooui/tree/base.py`).

### Test cases:

* Corrected typo in test description and added tests for `ConditionParser` to check involved fields (`spec/graph/helpers_spec.py`). [[1]](diffhunk://#diff-70ed69e2421fb078b2173114b8d24fbb3410ad5ab0cebc9b773ec5f4c92b2567L47-R47) [[2]](diffhunk://#diff-70ed69e2421fb078b2173114b8d24fbb3410ad5ab0cebc9b773ec5f4c92b2567R77-R83)
* Added comprehensive tests for the `Tree` class, including attributes and methods (`spec/tree/tree_spec.py`).