### PR TITLE
IMP add dateutil to domain eval functions

### DIFF
--- a/ooui/helpers/domain.py
+++ b/ooui/helpers/domain.py
@@ -3,6 +3,7 @@ import ast
 import operator
 import time
 import datetime
+import dateutil
 from simpleeval import EvalWithCompoundTypes, DEFAULT_OPERATORS, DEFAULT_NAMES
 
 
@@ -11,6 +12,7 @@ EVAL_FUNCTIONS = {
     'bool': bool,
     'datetime': datetime,
     'eval': ast.literal_eval,
+    'dateutil': dateutil,
 }
 
 


### PR DESCRIPTION
Allows `dateutil` to be used in domains. 

I.E: It allows dateutil library use in `totalDomain`'s as https://github.com/gisce/erp/pull/23895 