### PR TITLE
Allow parent values

### DIFF
--- a/ooui/helpers/domain.py
+++ b/ooui/helpers/domain.py
@@ -16,6 +16,20 @@ EVAL_FUNCTIONS = {
 }
 
 
+class DotDict(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError("object has no attribute '{}'".format(name))
+
+
+def make_dotdict(obj):
+    if isinstance(obj, dict):
+        return DotDict({k: make_dotdict(v) for k, v in obj.items()})
+    return obj
+
+
 class Domain(object):
     def __init__(self, domain):
         if not isinstance(domain, six.string_types):
@@ -30,6 +44,7 @@ class Domain(object):
 
         operators = DEFAULT_OPERATORS.copy()
         operators[ast.BitAnd] = operator.and_
+        values = make_dotdict(values)
         values.update(DEFAULT_NAMES.copy())
         s = EvalWithCompoundTypes(
             names=values, functions=EVAL_FUNCTIONS, operators=operators

--- a/spec/graph/helpers_spec.py
+++ b/spec/graph/helpers_spec.py
@@ -86,3 +86,11 @@ with description('Helpers module'):
             with it('should evaluate to false'):
                 d = Domain("")
                 expect(bool(d)).to(be_false)
+
+        with context("when the domain contains 'parent.invoice_id'"):
+            with it("should resolve the value correctly"):
+                domain_str = "[['invoice_id', '=', parent.invoice_id]]"
+                values = {'parent': {'invoice_id': 10}}
+                domain = Domain(domain_str)
+                result = domain.parse(values)
+                expect(result).to(equal([['invoice_id', '=', 10]]))


### PR DESCRIPTION
This pull request introduces a utility class and function to handle nested dictionary access more intuitively, updates the `Domain` class to leverage this new functionality, and adds a test case to validate the changes.

### Enhancements to dictionary handling:
* Added `DotDict` class and `make_dotdict` function in `ooui/helpers/domain.py` to enable attribute-style access for dictionaries and their nested structures. (`[ooui/helpers/domain.pyR19-R32](diffhunk://#diff-ce2f61937b0138a9d32f1418616449b9e2992878eb37e52100880ca2b36f7359R19-R32)`)

### Updates to the `Domain` class:
* Modified the `parse` method in `ooui/helpers/domain.py` to convert the `values` parameter into a `DotDict` for easier and more intuitive access to nested dictionary values. (`[ooui/helpers/domain.pyR47](diffhunk://#diff-ce2f61937b0138a9d32f1418616449b9e2992878eb37e52100880ca2b36f7359R47)`)

### Additional test coverage:
* Added a test case in `spec/graph/helpers_spec.py` to verify that the `Domain` class correctly resolves nested dictionary values using the new `DotDict` functionality. (`[spec/graph/helpers_spec.pyR89-R96](diffhunk://#diff-70ed69e2421fb078b2173114b8d24fbb3410ad5ab0cebc9b773ec5f4c92b2567R89-R96)`)