### PR TITLE
Feature tag parser on views

### DIFF
--- a/ooui/helpers/features.py
+++ b/ooui/helpers/features.py
@@ -1,0 +1,27 @@
+from lxml import etree
+
+
+def preprocess_feature_tags(xml_str, feature_checker):
+    doc = etree.fromstring(xml_str)
+
+    for node in doc.xpath('//feature'):
+        key = node.get('key')
+        status = node.get('status', 'enabled')
+        active = feature_checker(key)
+
+        if status == 'enabled':
+            condition_met = active
+        elif status == 'disabled':
+            condition_met = not active
+        else:
+            condition_met = True
+
+        parent = node.getparent()
+        if condition_met:
+            for child in list(node):
+                parent.insert(parent.index(node), child)
+            parent.remove(node)
+        else:
+            parent.remove(node)
+
+    return etree.tostring(doc)

--- a/spec/helpers/features_spec.py
+++ b/spec/helpers/features_spec.py
@@ -1,0 +1,112 @@
+from mamba import *
+from expects import *
+from ooui.helpers.features import preprocess_feature_tags
+
+
+from lxml import etree
+
+def xml_equal(xml1, xml2):
+    parser = etree.XMLParser(remove_blank_text=True)
+
+    tree1 = etree.fromstring(xml1, parser)
+    tree2 = etree.fromstring(xml2, parser)
+
+    canonical1 = etree.tostring(tree1, method='c14n')
+    canonical2 = etree.tostring(tree2, method='c14n')
+
+    return canonical1 == canonical2
+
+
+
+
+with description('preprocess_feature_tags'):
+
+    with it('removes feature nodes where the flag is not enabled'):
+        def feature_checker(key):
+            return key == "enabled.feature"
+
+        xml_input = """
+        <form>
+            <feature key="enabled.feature">
+                <field name="field_a" />
+            </feature>
+            <feature key="disabled.feature">
+                <field name="field_b" />
+            </feature>
+            <feature key="disabled.feature" status="disabled">
+                <field name="field_c" />
+            </feature>
+        </form>
+        """
+
+        result = preprocess_feature_tags(xml_input, feature_checker)
+
+        expected_xml = """
+            <form>
+            <field name="field_a" />
+            <field name="field_c" />
+            </form>
+        """
+
+        expect(xml_equal(result, expected_xml)).to(be_true)
+
+    with it('keeps all nodes if feature_checker always returns True'):
+        def feature_checker(key):
+            return True
+
+        xml_input = """
+        <form>
+            <feature key="any.feature">
+                <field name="field_x" />
+            </feature>
+        </form>
+        """
+
+        result = preprocess_feature_tags(xml_input, feature_checker)
+        expected_xml = """
+            <form>
+            <field name="field_x" />
+            </form>
+        """
+        expect(xml_equal(result, expected_xml)).to(be_true)
+
+    with it('removes all feature nodes if feature_checker always returns False'):
+        def feature_checker(key):
+            return False
+
+        xml_input = """
+        <form>
+            <feature key="any.feature">
+                <field name="field_x" />
+            </feature>
+        </form>
+        """
+
+        result = preprocess_feature_tags(xml_input, feature_checker)
+        expected_xml = """
+            <form>
+            </form>
+        """
+        expect(xml_equal(result, expected_xml)).to(be_true)
+
+    with it('removes parent feature if parent is not active even if child is active'):
+        def feature_checker(key):
+            return key == "enabled.child"
+
+        xml_input = """
+        <form>
+            <feature key="disabled.parent">
+                <field name="field_parent" />
+                <feature key="enabled.child">
+                    <field name="field_child" />
+                </feature>
+            </feature>
+        </form>
+        """
+
+        result = preprocess_feature_tags(xml_input, feature_checker)
+        expected_xml = """
+            <form>
+            </form>
+        """
+        expect(xml_equal(result, expected_xml)).to(be_true)


### PR DESCRIPTION
This pull request introduces a new helper function, `preprocess_feature_tags`, in `ooui/helpers/features.py` to manipulate XML documents based on feature flags. It also adds comprehensive test coverage in `spec/helpers/features_spec.py` to validate the functionality of the new method. The changes aim to streamline XML preprocessing by conditionally removing or retaining nodes based on feature status and a provided feature checker.

### XML Preprocessing Functionality:
* **`ooui/helpers/features.py`:** Added the `preprocess_feature_tags` function, which processes XML strings to dynamically include or exclude nodes based on their `key` and `status` attributes, using a `feature_checker` callback.

### Test Coverage:
* **`spec/helpers/features_spec.py`:** Added tests for `preprocess_feature_tags` to verify:
  - Nodes are removed if their feature is not enabled.
  - All nodes are retained when the feature checker always returns `True`.
  - All nodes are removed when the feature checker always returns `False`.
  - Parent nodes are removed when inactive, even if child nodes are active.


## Related
- https://github.com/gisce/webclient/issues/2236