### PR TITLE
return unicode text

### DIFF
--- a/ooui/helpers/features.py
+++ b/ooui/helpers/features.py
@@ -24,4 +24,4 @@ def preprocess_feature_tags(xml_str, feature_checker):
         else:
             parent.remove(node)
 
-    return etree.tostring(doc)
+    return etree.tostring(doc, encoding='unicode')


### PR DESCRIPTION
This pull request includes a small change to the `ooui/helpers/features.py` file. The change ensures that the `etree.tostring` function returns the string in Unicode encoding instead of the default byte encoding.