### PR TITLE
Chart: allow dynamic stacked

### DIFF
--- a/ooui/graph/chart.py
+++ b/ooui/graph/chart.py
@@ -92,15 +92,15 @@ class GraphChart(Graph):
                         'stacked': y_field.stacked
                     })
                 else:
-                    if y_field.stacked not in fields:
-                        values_grouped_by_y_label = get_values_grouped_by_field(
-                            y_field.label, fields, objects_for_x_value
-                        )
-                    else:
+                    if y_field.stacked in fields:
                         values_grouped_by_y_label = get_values_grouped_by_fields(
                             [y_field.label, y_field.stacked],
                             fields,
                             objects_for_x_value
+                        )
+                    else:
+                        values_grouped_by_y_label = get_values_grouped_by_field(
+                            y_field.label, fields, objects_for_x_value
                         )
 
                     for y_unique_value, grouped_entries in values_grouped_by_y_label.items():

--- a/ooui/graph/processor.py
+++ b/ooui/graph/processor.py
@@ -42,6 +42,35 @@ def get_values_for_y_field(entries, field_name, fields):
     ]
 
 
+def get_values_grouped_by_fields(fields_names, fields, values):
+    """
+    Group values by multiple fields.
+
+    :param list fields_names: A list of field names by which to group values.
+    :param dict fields: A dictionary containing field definitions.
+    :param list values: A list of dictionaries representing the values to be
+        grouped.
+
+    :rtype: dict
+    :returns: A dictionary where keys are tuples of field values and values are
+        dictionaries containing a label and an "entries" list.
+    """
+    grouped_values = {}
+
+    for entry in values:
+        key = tuple(get_value_and_label_for_field(fields, entry, field_name)['value']
+                    for field_name in fields_names)
+        label = ' - '.join(get_value_and_label_for_field(fields, entry, field_name)['label']
+                          for field_name in fields_names)
+
+        if key not in grouped_values:
+            grouped_values[key] = {'label': label, 'entries': []}
+
+        grouped_values[key]['entries'].append(entry)
+
+    return grouped_values
+
+
 def get_values_grouped_by_field(field_name, fields, values):
     """
     Group values by a specific field.

--- a/spec/graph/graph_spec.py
+++ b/spec/graph/graph_spec.py
@@ -35,6 +35,15 @@ with description('A Graph'):
         expect(graph.show_percent).to(be_true)
         expect(graph.suffix).to(equal('kW'))
 
+    with it('stacked attribute should be considered a field'):
+        xml = """<?xml version="1.0"?>
+    <graph type="bar" timerange="month" string="Ficheros B70">
+        <field name="create_date" string="Date" axis="x"/>                    
+        <field name="reclamacio" operator="count" axis="y" label="reclamacio" stacked="import_phase"/>
+    </graph>"""
+        graph = parse_graph(xml)
+        expect(graph.fields).to(contain('create_date', 'reclamacio', 'import_phase'))
+
     with it("should parse a chart graph XML with type line"):
         xml = """<?xml version="1.0"?>
     <graph type="line" y_range="auto">
@@ -95,4 +104,142 @@ with description('A Graph'):
                 result = graph.process(values, fields)
                 expect(result['yAxisProps']).to(equal({
                     'mode': 'full',
+                }))
+        with description("A bar graph with stacked field"):
+            with it("should read the stacked field"):
+                xml = """<?xml version="1.0"?>
+                    <graph type="bar" timerange="month" string="Ficheros B70">
+                        <field name="create_date" string="Date" axis="x"/>
+                        <field name="reclamacio" operator="count" axis="y" label="reclamacio" stacked="import_phase"/>
+                    </graph>"""
+                graph = parse_graph(xml)
+                fields = {
+                    'create_date': {'type': 'datetime', 'string': 'Create date'},
+                    'reclamacio': {'type': 'char', 'string': 'Reclamacio', 'size': 256},
+                    'import_phase': {'type': 'selection', 'selection': [('10', 'Phase 1'), ('20', 'Phase 2')], 'string': 'Import Phase'}
+                }
+                values = [
+                    {
+                        "create_date": "2025-03-03 21:00:57",
+                        "id": 504776,
+                        "reclamacio": "",
+                        "import_phase": "10",
+                    },
+                    {
+                        "create_date": "2025-02-28 21:01:07",
+                        "id": 504257,
+                        "reclamacio": "48-a2",
+                        "import_phase": "20",
+                    },
+                    {
+                        "create_date": "2025-02-28 21:00:41",
+                        "id": 503955,
+                        "reclamacio": "48-a2",
+                        "import_phase": "10",
+                    },
+                    {
+                        "create_date": "2025-02-27 21:01:59",
+                        "id": 503688,
+                        "reclamacio": "48-a3",
+                        "import_phase": "10",
+                    },
+                    {
+                        "create_date": "2025-02-07 21:00:39",
+                        "id": 488390,
+                        "reclamacio": "",
+                        "import_phase": "10",
+                    },
+                    {
+                        "create_date": "2025-01-27 21:01:02",
+                        "id": 478886,
+                        "reclamacio": "",
+                        "import_phase": "10",
+                    },
+                    {
+                        "create_date": "2025-01-24 21:01:20",
+                        "id": 478167,
+                        "reclamacio": "48-a3",
+                        "import_phase": "10",
+                    },
+                    {
+                        "create_date": "2025-01-23 21:00:45",
+                        "id": 477151,
+                        "reclamacio": "",
+                        "import_phase": "10",
+                    },
+                    {
+                        "create_date": "2025-01-23 21:00:43",
+                        "id": 477130,
+                        "reclamacio": "",
+                        "import_phase": "20",
+                    },
+                    {
+                        "create_date": "2025-01-08 21:00:58",
+                        "id": 467715,
+                        "reclamacio": "",
+                        "import_phase": "20",
+                    }
+                ]
+                result = graph.process(values, fields)
+                expect(result).to(equal({
+                    "num_items": 10,
+                    "type": "bar",
+                    "isGroup": True,
+                    "isStack": True,
+                    "data": [{
+                        "stacked": "10",
+                        "operator": "count",
+                        "x": "2025-01",
+                        "type": " - Phase 1",
+                        "value": 2.0
+                    },
+                    {
+                        "stacked": "20",
+                        "operator": "count",
+                        "x": "2025-01",
+                        "type": " - Phase 2",
+                        "value": 2.0
+                    },
+                    {
+                        "stacked": "10",
+                        "operator": "count",
+                        "x": "2025-01",
+                        "type": "48-a3 - Phase 1",
+                        "value": 1.0
+                    },
+                    {
+                        "stacked": "10",
+                        "operator": "count",
+                        "x": "2025-02",
+                        "type": " - Phase 1",
+                        "value": 1.0
+                    },
+                    {
+                        "stacked": "10",
+                        "operator": "count",
+                        "x": "2025-02",
+                        "type": "48-a2 - Phase 1",
+                        "value": 1.0
+                    },
+                    {
+                        "stacked": "20",
+                        "operator": "count",
+                        "x": "2025-02",
+                        "type": "48-a2 - Phase 2",
+                        "value": 1.0
+                    },
+                    {
+                        "stacked": "10",
+                        "operator": "count",
+                        "x": "2025-02",
+                        "type": "48-a3 - Phase 1",
+                        "value": 1.0
+                    },
+                    {
+                        "stacked": "10",
+                        "operator": "count",
+                        "x": "2025-03",
+                        "type": " - Phase 1",
+                        "value": 1.0
+                    }]
                 }))


### PR DESCRIPTION
This pull request enhances the `ooui/graph` module by introducing support for grouping and processing data based on multiple fields, including the `stacked` attribute. It also adds comprehensive tests to validate the new functionality. The most important changes are grouped below:

### Enhancements to Data Grouping and Processing:
* Added a new method `get_values_grouped_by_fields` in `ooui/graph/processor.py` to enable grouping values by multiple fields. This method generates keys as tuples of field values and supports creating combined labels.
* Updated the `process` method in `ooui/graph/chart.py` to handle cases where the `stacked` attribute is specified. It now uses `get_values_grouped_by_fields` when grouping by both `label` and `stacked` fields.
* Adjusted the `fields` method in `ooui/graph/chart.py` to include the `stacked` attribute as a field if it is defined.

### Bug Fixes and Improvements:
* Replaced the use of `y_field.stacked` directly with a dynamically determined `stacked` variable in the `process` method to ensure the correct value is used in all cases.

### Test Coverage:
* Added new test cases in `spec/graph/graph_spec.py` to verify that the `stacked` attribute is treated as a field and that bar graphs with stacked fields are processed correctly. These tests validate the grouping logic and ensure the output matches the expected format. [[1]](diffhunk://#diff-fa8d7c69523b61c9b8ebc293d4caff328d2e63e171e69525c4d0f1ac2bd93848R38-R46) [[2]](diffhunk://#diff-fa8d7c69523b61c9b8ebc293d4caff328d2e63e171e69525c4d0f1ac2bd93848R108-R245)