### PR TITLE
Add progressbar property to indicator result

### DIFF
--- a/ooui/graph/indicator.py
+++ b/ooui/graph/indicator.py
@@ -24,6 +24,8 @@ class GraphIndicator(Graph):
         ) or None
         self._show_percent = parse_bool_attribute(
             element.get('showPercent')) if element.get('showPercent') else False
+        self._progressbar = parse_bool_attribute(
+            element.get('progressbar')) if element.get('progressbar') else False
         self.domain_parse_values = {}
 
     @property
@@ -41,6 +43,10 @@ class GraphIndicator(Graph):
     @property
     def show_percent(self):
         return self._show_percent
+
+    @property
+    def progressbar(self):
+        return self._progressbar
 
     @property
     def suffix(self):
@@ -61,7 +67,9 @@ class GraphIndicator(Graph):
             res['color'] = self.color.eval(res)
         if self.icon:
             res['icon'] = self.icon.eval(res)
-        if not self.show_percent:
+        if self.progressbar:
+            res['progressbar'] = self.progressbar
+        if not self.show_percent and not self.progressbar:
             res.pop('percent', None)
         return res
 

--- a/ooui/graph/indicator.py
+++ b/ooui/graph/indicator.py
@@ -69,6 +69,8 @@ class GraphIndicator(Graph):
             res['icon'] = self.icon.eval(res)
         if self.progressbar:
             res['progressbar'] = self.progressbar
+        if self.show_percent:
+            res['showPercent'] = self.show_percent
         if not self.show_percent and not self.progressbar:
             res.pop('percent', None)
         return res

--- a/spec/graph/graph_spec.py
+++ b/spec/graph/graph_spec.py
@@ -52,6 +52,7 @@ with description('A Graph'):
         result = graph.process(50, 100)
         expect(result).to(have_key('percent', 50.0))
         expect(result).to(have_key('progressbar', True))
+        expect(result).not_to(have_key('showPercent'))
 
     with it('should calculate percent when showPercent is true'):
         xml = """<?xml version="1.0"?>
@@ -60,6 +61,7 @@ with description('A Graph'):
         graph = parse_graph(xml)
         result = graph.process(50, 100)
         expect(result).to(have_key('percent', 50.0))
+        expect(result).to(have_key('showPercent', True))
 
     with it('should not include percent when both progressbar and showPercent are false'):
         xml = """<?xml version="1.0"?>
@@ -69,6 +71,7 @@ with description('A Graph'):
         result = graph.process(50, 100)
         expect(result).not_to(have_key('percent'))
         expect(result).not_to(have_key('progressbar'))
+        expect(result).not_to(have_key('showPercent'))
 
     with it("should parse a chart graph XML with type line"):
         xml = """<?xml version="1.0"?>

--- a/spec/graph/graph_spec.py
+++ b/spec/graph/graph_spec.py
@@ -33,7 +33,42 @@ with description('A Graph'):
         expect(graph.fields).to(contain_only('potencia'))
         expect(graph.total_domain).to(be_none)
         expect(graph.show_percent).to(be_true)
+        expect(graph.progressbar).to(be_false)
         expect(graph.suffix).to(equal('kW'))
+
+    with it('should support progressbar attribute'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" progressbar="1" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        expect(graph.progressbar).to(be_true)
+        expect(graph.show_percent).to(be_false)
+
+    with it('should calculate percent when progressbar is true'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" progressbar="1" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        result = graph.process(50, 100)
+        expect(result).to(have_key('percent', 50.0))
+        expect(result).to(have_key('progressbar', True))
+
+    with it('should calculate percent when showPercent is true'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" showPercent="1" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        result = graph.process(50, 100)
+        expect(result).to(have_key('percent', 50.0))
+
+    with it('should not include percent when both progressbar and showPercent are false'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        result = graph.process(50, 100)
+        expect(result).not_to(have_key('percent'))
+        expect(result).not_to(have_key('progressbar'))
 
     with it("should parse a chart graph XML with type line"):
         xml = """<?xml version="1.0"?>


### PR DESCRIPTION
This pull request adds support for a new `progressbar` attribute to indicator graphs, allowing them to display a progress bar based on the value and total. The implementation includes updates to the `IndicatorGraph` class to parse and expose the new attribute, modifies the processing logic to handle progress bar display, and adds comprehensive tests to verify the new behavior.

**Indicator graph enhancements:**

* Added support for a `progressbar` attribute in the `IndicatorGraph` class, including parsing the attribute from XML and exposing it as a property. [[1]](diffhunk://#diff-cb3174138c7bff1efa334dd6bd87e3896e0b4b88cf36ba7453bb0e6823b293baR27-R28) [[2]](diffhunk://#diff-cb3174138c7bff1efa334dd6bd87e3896e0b4b88cf36ba7453bb0e6823b293baR47-R50)
* Updated the `process` method to include the `progressbar` key in the result when applicable, and to ensure the `percent` value is included when either `progressbar` or `showPercent` is true.

**Testing improvements:**

* Expanded the test suite in `graph_spec.py` to cover the new `progressbar` attribute, including its interaction with the `percent` value and different combinations of attributes.


## Related
- https://github.com/gisce/webclient/issues/2656