### PR TITLE
Add showTotal attribute to GraphIndicator

### DIFF
--- a/ooui/graph/indicator.py
+++ b/ooui/graph/indicator.py
@@ -24,6 +24,8 @@ class GraphIndicator(Graph):
         ) or None
         self._show_percent = parse_bool_attribute(
             element.get('showPercent')) if element.get('showPercent') else False
+        self._show_total = parse_bool_attribute(
+            element.get('showTotal')) if element.get('showTotal') else True
         self._progressbar = parse_bool_attribute(
             element.get('progressbar')) if element.get('progressbar') else False
         self.domain_parse_values = {}
@@ -43,6 +45,10 @@ class GraphIndicator(Graph):
     @property
     def show_percent(self):
         return self._show_percent
+
+    @property
+    def show_total(self):
+        return self._show_total
 
     @property
     def progressbar(self):
@@ -71,6 +77,7 @@ class GraphIndicator(Graph):
             res['progressbar'] = self.progressbar
         if self.show_percent:
             res['showPercent'] = self.show_percent
+        res['showTotal'] = self.show_total
         if not self.show_percent and not self.progressbar:
             res.pop('percent', None)
         return res

--- a/spec/graph/graph_spec.py
+++ b/spec/graph/graph_spec.py
@@ -33,6 +33,7 @@ with description('A Graph'):
         expect(graph.fields).to(contain_only('potencia'))
         expect(graph.total_domain).to(be_none)
         expect(graph.show_percent).to(be_true)
+        expect(graph.show_total).to(be_true)
         expect(graph.progressbar).to(be_false)
         expect(graph.suffix).to(equal('kW'))
 
@@ -72,6 +73,50 @@ with description('A Graph'):
         expect(result).not_to(have_key('percent'))
         expect(result).not_to(have_key('progressbar'))
         expect(result).not_to(have_key('showPercent'))
+
+    with it('should include showTotal by default'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        expect(graph.show_total).to(be_true)
+        result = graph.process(50, 100)
+        expect(result).to(have_key('showTotal', True))
+
+    with it('should support showTotal="0" to disable'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" showTotal="0" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        expect(graph.show_total).to(be_false)
+        result = graph.process(50, 100)
+        expect(result).to(have_key('showTotal', False))
+
+    with it('should support showTotal="1" explicitly'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" showTotal="1" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        expect(graph.show_total).to(be_true)
+        result = graph.process(50, 100)
+        expect(result).to(have_key('showTotal', True))
+
+    with it('should always include showTotal in response'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" type="indicator" />
+        """
+        graph = parse_graph(xml)
+        result = graph.process(50, 100)
+        expect(result).to(have_key('showTotal'))
+        expect(result['showTotal']).to(be_true)
+        
+        xml_false = """<?xml version="1.0"?>
+        <graph string="My indicator" showTotal="0" type="indicator" />
+        """
+        graph_false = parse_graph(xml_false)
+        result_false = graph_false.process(50, 100)
+        expect(result_false).to(have_key('showTotal'))
+        expect(result_false['showTotal']).to(be_false)
 
     with it("should parse a chart graph XML with type line"):
         xml = """<?xml version="1.0"?>

--- a/spec/graph/processor_spec.py
+++ b/spec/graph/processor_spec.py
@@ -68,6 +68,7 @@ with description('When process a graph'):
             icon='slack',
             suffix='kW',
             type='indicatorField',
+            showTotal=True,
         ))
 
     with it('should process indicator graph'):
@@ -89,6 +90,31 @@ with description('When process a graph'):
             color='green',
             icon='slack',
             type='indicator',
+        ))
+
+    with it('should process indicatorField graph with showTotal="0"'):
+        xml = """<?xml version="1.0"?>
+        <graph string="My indicator" showPercent="1" showTotal="0" type="indicatorField" color="red:value>0;green:value==0" totalDomain="[]" icon="slack" suffix="kW">
+            <field name="potencia" operator="+" />
+        </graph>
+        """
+        total_values = models['polissa'].data
+        t20A_values = [v for v in total_values if v['tarifa'][1] == "2.0A"]
+        g = parse_graph(xml)
+        result = g.process(
+            t20A_values,
+            fields=models['polissa'].fields,
+            total_values=total_values
+        )
+        expect(result).to(have_keys(
+            value=77.72,
+            percent=28.19,
+            total=275.72,
+            color='red',
+            icon='slack',
+            suffix='kW',
+            type='indicatorField',
+            showTotal=False,
         ))
 
     # Un test per quan el total sigui 0 no falli al calcular el percentatge


### PR DESCRIPTION
This pull request introduces support for a new `showTotal` attribute in the indicator graph type, allowing users to control whether the total value is displayed. By default, `showTotal` is enabled unless explicitly set to `"0"`. The changes also include updates to processing logic and comprehensive tests to verify the new behavior.

**Indicator graph enhancements:**

* Added a new `showTotal` attribute to the `Indicator` class in `ooui/graph/indicator.py`, defaulting to `True` unless specified otherwise in the XML. This allows users to toggle the display of the total value.
* Exposed a `show_total` property and updated the `process` method to include `showTotal` in the output only when enabled. [[1]](diffhunk://#diff-cb3174138c7bff1efa334dd6bd87e3896e0b4b88cf36ba7453bb0e6823b293baR49-R52) [[2]](diffhunk://#diff-cb3174138c7bff1efa334dd6bd87e3896e0b4b88cf36ba7453bb0e6823b293baR80-R81)

**Testing and validation:**

* Added multiple tests in `spec/graph/graph_spec.py` to verify default behavior, explicit enabling/disabling, and correct output of `showTotal`.
* Updated existing tests to check for the presence of `showTotal` in processed graph results.
* Added a test in `spec/graph/processor_spec.py` to verify that disabling `showTotal` via XML omits it from the result. [[1]](diffhunk://#diff-612284eeab3fec25645e8fe00e28aa46000d15996aa24168ac26e6fc099bcce7R71) [[2]](diffhunk://#diff-612284eeab3fec25645e8fe00e28aa46000d15996aa24168ac26e6fc099bcce7R95-R119)